### PR TITLE
Add env var to set allowed-origin header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following environment variables can be set to configure the service:
 - `API_KEY`: The API key to be used for the proxied calls.
 - `API_KEY_HEADER`: The header to which the API key is added. Default is `X-Api-Key`.
 - `REQUIRED_ROLES`: A comma-separated list of roles that are required to access the service. Default is empty. If set, the service will check if the session has any of the roles assigned before proxying the call. If not set or empty, no check is performed.
+- `ALLOWED_ORIGIN`: A static override for the access-control-allow-origin header to be set for every response. Defaults to not setting this header.
 
 ## Setup in a `mu-semtech` Docker stack
 

--- a/app.ts
+++ b/app.ts
@@ -27,6 +27,7 @@ const env = cleanEnv(process.env, {
   API_URL: url(),
   API_KEY_HEADER: str({ default: "x-api-key" }),
   REQUIRED_ROLES: requiredRolesValidator({ default: [] }),
+  ALLOWED_ORIGIN: str({ default: "" }),
 });
 
 app.use(bodyParser.json({ limit: "50mb" }));
@@ -78,6 +79,9 @@ app.use(
             if (!(await isSessionAuthorized(muSessionId, requiredRoles))) {
               return res.status(403).send();
             }
+          }
+          if (env.ALLOWED_ORIGIN) {
+            res.setHeader("access-control-allow-origin", env.ALLOWED_ORIGIN);
           }
         });
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "lmb-sparql-proxy",
       "version": "0.0.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.1",
         "body-parser": "^1.20.2",


### PR DESCRIPTION
Allows for use without the identifier and dispatcher from a normal semantic works stack.