### PR TITLE
Add support for providing `http-proxy-middleware` plugins

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -1,0 +1,13 @@
+steps:
+  build-and-push:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: "${CI_REPO}"
+      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+when:
+  - event: push
+    branch: [feature/*]

--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -4,6 +4,7 @@ steps:
     settings:
       repo: "${CI_REPO}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+      platforms: linux/amd64,linux/arm64
       username:
         from_secret: docker_username
       password:

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,11 +1,14 @@
-pipeline:
+steps:
   build:
     image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       tags: latest
       platforms: linux/amd64,linux/arm64
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  branch: master
-  event: push
+  - event: push
+    branch: master

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,11 +1,14 @@
-pipeline:
+steps:
   build:
     image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       tags: "${CI_COMMIT_TAG##v}"
       platforms: linux/amd64,linux/arm64
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  event: tag
-  tag: v*
+  - event: tag
+    tag: v*

--- a/.woodpecker/.test-build.yml
+++ b/.woodpecker/.test-build.yml
@@ -1,4 +1,4 @@
-pipeline:
+steps:
   lint:
     image: node:20-alpine
     commands:
@@ -11,5 +11,4 @@ pipeline:
       repo: ${CI_REPO}
       dry_run: true
 when:
-  event:
-    - pull_request
+  - event: pull_request

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This particular proxy service proxies all calls made to `/` to the configured `A
 The following environment variables can be set to configure the service:
 
 - `API_URL`: The URL to which all calls are proxied.
-- `API_KEY`: The API key to be used for the proxied calls.
+- `API_KEY`: The API key to be used for the proxied calls. (Optional)
 - `API_KEY_HEADER`: The header to which the API key is added. Default is `X-Api-Key`.
 - `REQUIRED_ROLES`: A comma-separated list of roles that are required to access the service. Default is empty. If set, the service will check if the session has any of the roles assigned before proxying the call. If not set or empty, no check is performed.
 - `ALLOWED_ORIGIN`: A static override for the access-control-allow-origin header to be set for every response. Defaults to not setting this header.

--- a/app.ts
+++ b/app.ts
@@ -5,6 +5,7 @@ import { querySudo as query } from "@lblod/mu-auth-sudo";
 import { Request, Response } from "express";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { cleanEnv, EnvError, makeValidator, str, url } from "envalid";
+import plugins from "./config/plugins";
 
 const requiredRolesValidator = makeValidator((x) => {
   try {
@@ -85,6 +86,7 @@ app.use(
           }
         });
       },
+      ...plugins,
     ],
   }),
 );

--- a/app.ts
+++ b/app.ts
@@ -24,7 +24,7 @@ const requiredRolesValidator = makeValidator((x) => {
 });
 
 const env = cleanEnv(process.env, {
-  API_KEY: str(),
+  API_KEY: str({ default: undefined }),
   API_URL: url(),
   API_KEY_HEADER: str({ default: "x-api-key" }),
   REQUIRED_ROLES: requiredRolesValidator({ default: [] }),
@@ -60,9 +60,11 @@ app.use(
   createProxyMiddleware<Request, Response>({
     target: env.API_URL,
     changeOrigin: true,
-    headers: {
-      [env.API_KEY_HEADER]: env.API_KEY,
-    },
+    headers: env.API_KEY
+      ? {
+          [env.API_KEY_HEADER]: env.API_KEY,
+        }
+      : {},
     pathRewrite: (_path, req) =>
       req.originalUrl ?? `${req.baseUrl || ""}${req.url}`,
     plugins: [

--- a/config/plugins.ts
+++ b/config/plugins.ts
@@ -1,0 +1,6 @@
+import type { Plugin } from "http-proxy-middleware";
+import { Request, Response } from "express";
+
+const plugins: Plugin<Request, Response>[] = [];
+
+export default plugins;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@lblod/mu-auth-sudo": "^0.6.1",
         "body-parser": "^1.20.2",
         "envalid": "^8.0.0",
-        "http-proxy-middleware": "^3.0.0"
+        "http-proxy-middleware": "^3.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.3.0",
@@ -283,9 +283,10 @@
       "dev": true
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.14",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
-      "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1689,27 +1690,29 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz",
-      "integrity": "sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.10",
-        "debug": "^4.3.4",
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
         "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.5"
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/http-proxy-middleware/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1721,9 +1724,10 @@
       }
     },
     "node_modules/http-proxy-middleware/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
@@ -1845,15 +1849,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-typedarray": {
@@ -2011,9 +2013,10 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@lblod/mu-auth-sudo": "^0.6.1",
     "body-parser": "^1.20.2",
     "envalid": "^8.0.0",
-    "http-proxy-middleware": "^3.0.0"
+    "http-proxy-middleware": "^3.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.3.0",


### PR DESCRIPTION
The `http-proxy-middleware` package supports customizing it behaviours throug plugins (https://github.com/chimurai/http-proxy-middleware?tab=readme-ov-file#plugins-array).
This PR adjusts this service so its plugins can be configured through a `config/plugins.{js|ts}` file.